### PR TITLE
Add new accept header to allow creating labels with descriptions and :emoji: shorthand

### DIFF
--- a/lib/create-labels.js
+++ b/lib/create-labels.js
@@ -8,6 +8,9 @@ module.exports = ({ project, labels, token } = {}) => {
       try {
         await Promise.all([
           ghGot.post(`repos/${project}/labels`, {
+            headers: {
+              'accept': 'application/vnd.github.symmetra-preview+json'
+            },
             body: label,
             token
           })

--- a/lib/get-labels.js
+++ b/lib/get-labels.js
@@ -4,7 +4,12 @@ const ghGot = require('gh-got')
 
 module.exports = async ({ project, token } = {}) => {
   try {
-    const { body } = await ghGot(`repos/${project}/labels`, { token })
+    const { body } = await ghGot(`repos/${project}/labels`, {
+      headers: {
+        'accept': 'application/vnd.github.symmetra-preview+json'
+      },
+      token
+    })
 
     return body
   } catch (error) {


### PR DESCRIPTION
There's a new accept header for the label api to allow creating/retrieving labels with descriptions and :emoji: shorthand.

See also: https://developer.github.com/v3/issues/labels/